### PR TITLE
Refactor URL launcher and remove privilege check

### DIFF
--- a/src/OverwatchServerBlocker.Core/Utilities/Launcher.cs
+++ b/src/OverwatchServerBlocker.Core/Utilities/Launcher.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace OverwatchServerBlocker.Core.Utilities;
 
@@ -7,19 +6,15 @@ public static class Launcher
 {
     public static void OpenUrl(string url)
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+#if WINDOWS
+        Process.Start(new ProcessStartInfo
         {
-            Process.Start("xdg-open", url);
-        }
-        else
-        {
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? url : "open",
-                Arguments = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : $"{url}",
-                CreateNoWindow = true,
-                UseShellExecute = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            });
-        }
+            FileName = url,
+            CreateNoWindow = true,
+            UseShellExecute = true
+        });
+#else
+        Process.Start("xdg-open", $"\"{url}\"");
+#endif
     }
 }

--- a/src/OverwatchServerBlocker.Linux/OverwatchServerBlocker.Linux.csproj
+++ b/src/OverwatchServerBlocker.Linux/OverwatchServerBlocker.Linux.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-        <ApplicationManifest>app.manifest</ApplicationManifest>
         <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     </PropertyGroup>
 

--- a/src/OverwatchServerBlocker.UI/App.axaml.cs
+++ b/src/OverwatchServerBlocker.UI/App.axaml.cs
@@ -38,19 +38,6 @@ public partial class App : Application
         {
             BindingPlugins.DataValidators.RemoveAt(0);
 
-#if RELEASE
-            if (!System.Environment.IsPrivilegedProcess)
-            {
-                try
-                {
-                    TranslationProvider.SetCulture(CultureInfo.InstalledUICulture);
-                }
-                catch {}
-                desktop.MainWindow = new PrivilegeWindow();
-                return;
-            }
-#endif
-
             Logs.TryDeleteLogs();
             desktop.MainWindow = new MainWindow
             {


### PR DESCRIPTION
Simplified the OpenUrl method in Launcher.cs to use platform-specific compilation instead of runtime checks. Removed the privilege check and related culture setting logic from App.axaml.cs. Also removed the ApplicationManifest property from the Linux project file.