### PR TITLE
Refactor main window to use MainView to support single view lifetimes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/shad-ui"]
+	path = vendor/shad-ui
+	url = https://github.com/1000374/shad-ui.git

--- a/src/OverwatchServerBlocker.Core/Localization/Arabic/Misc_ar.toml
+++ b/src/OverwatchServerBlocker.Core/Localization/Arabic/Misc_ar.toml
@@ -1,6 +1,7 @@
 ﻿elevated_privileges = "يتطلب هذا التطبيق صلاحيات عالية للتشغيل"
 
 window_title = "حاظر سيرفرات اوفرواتش"
+github = "جيت هب"
 github_repository = "مشروع جيت هب"
 check_update = "تحقق من وجود تحديث"
 

--- a/src/OverwatchServerBlocker.Core/Localization/English/Misc.toml
+++ b/src/OverwatchServerBlocker.Core/Localization/English/Misc.toml
@@ -7,6 +7,7 @@ generated_namespace = "OverwatchServerBlocker.Core.Localization"
 elevated_privileges = "This program requires elevated privileges to run"
 
 window_title = "Overwatch Server Blocker"
+github = "Github"
 github_repository = "Github Repository"
 check_update = "Check Update"
 

--- a/src/OverwatchServerBlocker.Core/Services/IAppManager.cs
+++ b/src/OverwatchServerBlocker.Core/Services/IAppManager.cs
@@ -4,11 +4,11 @@ namespace OverwatchServerBlocker.Core.Services;
 
 public interface IAppManager
 {
-    public event EventHandler MainWindowLoaded;
+    public event EventHandler MainViewLoaded;
 
-    public void InvokeMainWindowLoaded(object? sender);
+    public void InvokeMainViewLoaded(object? sender);
 
-    public bool IsMainWindowLoaded { get; }
+    public bool IsMainViewLoaded { get; }
 
     public void SetTheme(Theme theme);
 }

--- a/src/OverwatchServerBlocker.Core/ViewModels/MainViewModel.cs
+++ b/src/OverwatchServerBlocker.Core/ViewModels/MainViewModel.cs
@@ -9,6 +9,7 @@ namespace OverwatchServerBlocker.Core.ViewModels;
 public partial class MainViewModel : ViewModelBase
 {
     private readonly ILogger<MainViewModel> _logger;
+    public IAppManager AppManager { get; }
     public IDialogManager DialogManager { get; }
     public IToastManager ToastManager { get; }
     public Navigation Navigation { get; }
@@ -16,12 +17,14 @@ public partial class MainViewModel : ViewModelBase
 
     public MainViewModel(
         ILogger<MainViewModel> logger,
+        IAppManager appManager,
         IDialogManager dialogManager,
         IToastManager toastManager,
         Navigation navigation,
         UpdateChecker updateChecker)
     {
         _logger = logger;
+        AppManager = appManager;
         DialogManager = dialogManager;
         ToastManager = toastManager;
         Navigation = navigation;

--- a/src/OverwatchServerBlocker.UI/App.axaml.cs
+++ b/src/OverwatchServerBlocker.UI/App.axaml.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
+using System.Linq;
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
@@ -9,8 +9,13 @@ using Echoes;
 using Microsoft.Extensions.DependencyInjection;
 using OverwatchServerBlocker.Core;
 using OverwatchServerBlocker.Core.Services;
-using OverwatchServerBlocker.Core.Utilities;
 using OverwatchServerBlocker.Core.ViewModels;
+
+#if RELEASE
+using OverwatchServerBlocker.Core.Utilities;
+#else
+using Avalonia.Controls;
+#endif
 
 namespace OverwatchServerBlocker.UI;
 
@@ -33,34 +38,45 @@ public partial class App : Application
             DesignTime.Locator.BuildProvider();
         }
 #endif
+        foreach (var plugin in BindingPlugins.DataValidators.OfType<DataAnnotationsValidationPlugin>().ToArray())
+        {
+            BindingPlugins.DataValidators.Remove(plugin);
+        }
+
+#if RELEASE
+        Logs.TryDeleteLogs();
+#endif
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            BindingPlugins.DataValidators.RemoveAt(0);
-
-            Logs.TryDeleteLogs();
-            desktop.MainWindow = new MainWindow
-            {
-                DataContext = Singletons.ServiceProvider?.GetRequiredService<MainViewModel>()
-            };
-
-            IAppManager? appManager = Singletons.ServiceProvider?.GetRequiredService<IAppManager>();
-            if (appManager is not null)
-            {
-                desktop.MainWindow.Loaded += (_, _) => appManager.InvokeMainWindowLoaded(this);
-            }
-
-            SettingsManager? manager = Singletons.ServiceProvider?.GetRequiredService<SettingsManager>();
-            if (manager is not null)
-            {
-                manager.CultureChanged += ManagerOnCultureChanged;
-                manager.TryLoad();
-            }
-
-            Singletons.ServiceProvider?.GetRequiredService<UpdateChecker>().CheckStartup();
+            DesktopStartup(desktop);
         }
 
+        SettingsManager? manager = Singletons.ServiceProvider?.GetRequiredService<SettingsManager>();
+        if (manager is not null)
+        {
+            manager.CultureChanged += ManagerOnCultureChanged;
+            manager.TryLoad();
+        }
+
+        Singletons.ServiceProvider?.GetRequiredService<UpdateChecker>().CheckStartup();
+
         base.OnFrameworkInitializationCompleted();
+    }
+
+    private void DesktopStartup(IClassicDesktopStyleApplicationLifetime lifetime)
+    {
+#if WINDOWS
+        lifetime.MainWindow = new ShadMainWindow
+        {
+            DataContext = Singletons.ServiceProvider?.GetRequiredService<MainViewModel>()
+        };
+#else
+        lifetime.MainWindow = new MainWindow
+        {
+            DataContext = Singletons.ServiceProvider?.GetRequiredService<MainViewModel>()
+        };
+#endif
     }
 
     private void ManagerOnCultureChanged(object? sender, string e)
@@ -71,6 +87,10 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: not null } desktop)
         {
             desktop.MainWindow.FlowDirection = info.TextInfo.IsRightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+        }
+        else if (ApplicationLifetime is ISingleViewApplicationLifetime { MainView: not null } singleView)
+        {
+            singleView.MainView.FlowDirection = info.TextInfo.IsRightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
         }
     }
 }

--- a/src/OverwatchServerBlocker.UI/MainWindow.axaml
+++ b/src/OverwatchServerBlocker.UI/MainWindow.axaml
@@ -1,140 +1,29 @@
-<shadui:Window x:Class="OverwatchServerBlocker.UI.MainWindow"
-               xmlns="https://github.com/avaloniaui"
-               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-               xmlns:converters="clr-namespace:OverwatchServerBlocker.UI.Converters"
-               xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-               xmlns:designTime="clr-namespace:OverwatchServerBlocker.UI.DesignTime;assembly=OverwatchServerBlocker.UI"
-               xmlns:echoes="clr-namespace:Echoes;assembly=Echoes.Avalonia"
-               xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
-               xmlns:localization="clr-namespace:OverwatchServerBlocker.Core.Localization;assembly=OverwatchServerBlocker.Core"
-               xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-               xmlns:services="clr-namespace:OverwatchServerBlocker.Core.Services;assembly=OverwatchServerBlocker.Core"
-               xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
-               xmlns:ui="clr-namespace:OverwatchServerBlocker.UI"
-               xmlns:vm="clr-namespace:OverwatchServerBlocker.Core.ViewModels;assembly=OverwatchServerBlocker.Core"
-               Title="{echoes:Translate {x:Static localization:Misc.window_title}}"
-               MinWidth="790"
-               MinHeight="300"
-               d:DesignHeight="450"
-               d:DesignWidth="800"
-               x:DataType="vm:MainViewModel"
-               Icon="/Assets/logo-gray.ico"
-               SaveWindowState="True"
-               ShowBottomBorder="False"
-               TitleFontWeight="SemiBold"
-               mc:Ignorable="d">
+﻿<Window x:Class="OverwatchServerBlocker.UI.MainWindow"
+        xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:designTime="clr-namespace:OverwatchServerBlocker.UI.DesignTime;assembly=OverwatchServerBlocker.UI"
+        xmlns:echoes="clr-namespace:Echoes;assembly=Echoes.Avalonia"
+        xmlns:localization="clr-namespace:OverwatchServerBlocker.Core.Localization;assembly=OverwatchServerBlocker.Core"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:ui="clr-namespace:OverwatchServerBlocker.UI"
+        xmlns:views="clr-namespace:OverwatchServerBlocker.UI.Views"
+        xmlns:vm="clr-namespace:OverwatchServerBlocker.Core.ViewModels;assembly=OverwatchServerBlocker.Core"
+        Title="{echoes:Translate {x:Static localization:Misc.window_title}}"
+        MinWidth="790"
+        MinHeight="330"
+        d:DesignHeight="450"
+        d:DesignWidth="800"
+        x:DataType="vm:MainViewModel"
+        Icon="/Assets/logo-gray.ico"
+        mc:Ignorable="d">
     <Design.DataContext>
         <designTime:Locator Type="{x:Type vm:MainViewModel}" />
     </Design.DataContext>
 
-    <shadui:Window.DataTemplates>
+    <Window.DataTemplates>
         <ui:ViewLocator />
-    </shadui:Window.DataTemplates>
+    </Window.DataTemplates>
 
-    <shadui:Window.Hosts>
-        <shadui:DialogHost x:Name="DialogHost"
-                           Owner="{Binding $parent[Window]}" />
-        <shadui:ToastHost x:Name="ToastHost" />
-    </shadui:Window.Hosts>
-
-    <shadui:Window.LogoContent>
-        <Image Margin="18,8,8,8"
-               Source="/Assets/logo-transparent.png" />
-    </shadui:Window.LogoContent>
-
-    <shadui:Window.Styles>
-        <Style Selector="PathIcon#CheckSelected">
-            <Setter Property="FlowDirection" Value="LeftToRight" />
-        </Style>
-        <Style Selector="PathIcon#PartIcon">
-            <Setter Property="FlowDirection" Value="LeftToRight" />
-        </Style>
-    </shadui:Window.Styles>
-
-    <shadui:Window.RightWindowTitleBarContent>
-        <StackPanel Orientation="Horizontal"
-                    Spacing="8">
-            <Button Width="30"
-                    Height="30"
-                    Command="{Binding OpenRepositoryCommand}"
-                    Content="{iconPacks:FontAwesome GithubBrands,
-                                                    Width=16,
-                                                    Height=16}"
-                    ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.github_repository}}" />
-            <Button Width="30"
-                    Height="30"
-                    Command="{Binding UpdateChecker.CheckForUpdatesCommand}"
-                    ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.check_update}}">
-                <iconPacks:PackIconFontAwesome Width="16"
-                                               Height="16"
-                                               ClipToBounds="False"
-                                               Kind="RotateSolid"
-                                               Spin="{Binding UpdateChecker.IsCheckingUpdate}"
-                                               SpinDuration="3" />
-            </Button>
-        </StackPanel>
-    </shadui:Window.RightWindowTitleBarContent>
-
-    <Grid ColumnDefinitions="Auto, *">
-        <shadui:Sidebar Grid.Column="0"
-                        Width="220"
-                        MinWidth="60"
-                        Padding="{Binding #Toggler.IsChecked, Converter={x:Static converters:BooleanConverters.SidebarPadding}}"
-                        BorderBrush="{DynamicResource BorderColor30}"
-                        BorderThickness="0,0,1,0"
-                        CurrentRoute="{Binding Navigation.CurrentPage.Route}"
-                        Expanded="{Binding #Toggler.IsChecked}">
-            <shadui:Sidebar.Header>
-                <ToggleButton Name="Toggler"
-                              Height="32"
-                              Padding="8"
-                              HorizontalAlignment="{Binding #Toggler.IsChecked, Converter={x:Static converters:BooleanConverters.SidebarTogglerHorizontalAlignment}}"
-                              CornerRadius="{DynamicResource LgCornerRadius}"
-                              Theme="{DynamicResource SideTogglerTheme}"
-                              ToolTip.ServiceEnabled="{Binding !$parent[shadui:Sidebar].Expanded}"
-                              ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.nav_expand}}">
-                    <iconPacks:PackIconFontAwesome Width="16"
-                                                   Height="16"
-                                                   HorizontalAlignment="Center"
-                                                   Kind="BarsStaggeredSolid" />
-                </ToggleButton>
-            </shadui:Sidebar.Header>
-
-            <shadui:Sidebar.ExpandEasing>
-                <shadui:EaseInOutBack BounceIntensity="Strong" />
-            </shadui:Sidebar.ExpandEasing>
-
-            <StackPanel Spacing="4">
-                <shadui:SidebarItemLabel AsSeparator="True" />
-                <shadui:SidebarItem Command="{Binding Navigation.NavigateCommand}"
-                                    CommandParameter="{x:Static services:Pages.Servers}"
-                                    Content="{echoes:Translate {x:Static localization:Misc.nav_servers}}"
-                                    Route="Servers"
-                                    ToolTip.ServiceEnabled="{Binding !$parent[shadui:Sidebar].Expanded}"
-                                    ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.nav_servers}}">
-                    <shadui:SidebarItem.Icon>
-                        <iconPacks:PackIconFontAwesome Width="16"
-                                                       Height="16"
-                                                       VerticalAlignment="Center"
-                                                       Kind="ServerSolid" />
-                    </shadui:SidebarItem.Icon>
-                </shadui:SidebarItem>
-                <shadui:SidebarItem Command="{Binding Navigation.NavigateCommand}"
-                                    CommandParameter="{x:Static services:Pages.Settings}"
-                                    Content="{echoes:Translate {x:Static localization:Misc.nav_settings}}"
-                                    Route="Settings"
-                                    ToolTip.ServiceEnabled="{Binding !$parent[shadui:Sidebar].Expanded}"
-                                    ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.nav_settings}}">
-                    <shadui:SidebarItem.Icon>
-                        <iconPacks:PackIconFontAwesome Width="16"
-                                                       Height="16"
-                                                       VerticalAlignment="Center"
-                                                       Kind="GearsSolid" />
-                    </shadui:SidebarItem.Icon>
-                </shadui:SidebarItem>
-            </StackPanel>
-        </shadui:Sidebar>
-        <ContentControl Grid.Column="1"
-                        Content="{Binding Navigation.CurrentPage}" />
-    </Grid>
-</shadui:Window>
+    <views:MainView DataContext="{Binding}" />
+</Window>

--- a/src/OverwatchServerBlocker.UI/MainWindow.axaml.cs
+++ b/src/OverwatchServerBlocker.UI/MainWindow.axaml.cs
@@ -1,11 +1,4 @@
-using System;
-using System.Reflection;
-using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
-using Avalonia.Layout;
-using OverwatchServerBlocker.Core.ViewModels;
-using OverwatchServerBlocker.UI.Services;
-using Window = ShadUI.Window;
+﻿using Avalonia.Controls;
 
 namespace OverwatchServerBlocker.UI;
 
@@ -14,51 +7,5 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-
-#if DEBUG
-        if (Design.IsDesignMode)
-        {
-            TitleBarAnimationEnabled = false;
-        }
-#endif
-    }
-
-    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-    {
-        base.OnApplyTemplate(e);
-
-        string? version = Assembly.GetEntryAssembly()?.GetName().Version?.ToString(3);
-        if (string.IsNullOrEmpty(version))
-        {
-            return;
-        }
-
-        StackPanel? panel = e.NameScope.Find<StackPanel>("AppTitlePanel");
-        panel?.Children.Add(new TextBlock
-        {
-            Text = version,
-            Classes = { "Muted" },
-            VerticalAlignment = VerticalAlignment.Center
-        });
-    }
-
-    protected override void OnDataContextChanged(EventArgs e)
-    {
-        base.OnDataContextChanged(e);
-
-        if (DataContext is not MainViewModel mainViewModel)
-        {
-            return;
-        }
-
-        if (mainViewModel.DialogManager is DialogManager dialogManager)
-        {
-            DialogHost.Manager = dialogManager.Manager;
-        }
-
-        if (mainViewModel.ToastManager is ToastManager toastManager)
-        {
-            ToastHost.Manager = toastManager.Manager;
-        }
     }
 }

--- a/src/OverwatchServerBlocker.UI/OverwatchServerBlocker.UI.csproj
+++ b/src/OverwatchServerBlocker.UI/OverwatchServerBlocker.UI.csproj
@@ -16,10 +16,12 @@
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.1.1" />
         <PackageReference Include="Echoes.Avalonia" Version="0.3.0" />
         <PackageReference Include="IconPacks.Avalonia.FontAwesome" Version="1.3.1" />
-        <PackageReference Include="ShadUI" Version="0.1.5" />
+        <!-- <PackageReference Include="ShadUI" Version="0.1.5" /> -->
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\OverwatchServerBlocker.Core\OverwatchServerBlocker.Core.csproj" />
+      <!-- TODO: Replace with official package -->
+      <ProjectReference Include="..\..\vendor\shad-ui\src\ShadUI\ShadUI.csproj" />
     </ItemGroup>
 </Project>

--- a/src/OverwatchServerBlocker.UI/Services/AppManager.cs
+++ b/src/OverwatchServerBlocker.UI/Services/AppManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Styling;
 using OverwatchServerBlocker.Core.Models;
@@ -9,14 +10,14 @@ namespace OverwatchServerBlocker.UI.Services;
 
 public class AppManager : IAppManager
 {
-    public event EventHandler? MainWindowLoaded;
+    public event EventHandler? MainViewLoaded;
 
-    public void InvokeMainWindowLoaded(object? sender)
+    public void InvokeMainViewLoaded(object? sender)
     {
-        MainWindowLoaded?.Invoke(sender, EventArgs.Empty);
+        MainViewLoaded?.Invoke(sender, EventArgs.Empty);
     }
 
-    public bool IsMainWindowLoaded => Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow.IsLoaded: true };
+    public bool IsMainViewLoaded => CheckView();
 
     public void SetTheme(Theme theme)
     {
@@ -33,5 +34,19 @@ public class AppManager : IAppManager
             Theme.Dark => ThemeVariant.Dark,
             _ => ThemeVariant.Default
         };
+    }
+
+    public bool CheckView()
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            return desktop.MainWindow?.Content is Control { IsLoaded: true };
+        }
+        if (Application.Current?.ApplicationLifetime is ISingleViewApplicationLifetime singleView)
+        {
+            return singleView.MainView is { IsLoaded: true };
+        }
+
+        return false;
     }
 }

--- a/src/OverwatchServerBlocker.UI/Services/DialogManager.cs
+++ b/src/OverwatchServerBlocker.UI/Services/DialogManager.cs
@@ -21,10 +21,10 @@ public class DialogManager : IDialogManager
         Manager = manager;
         _appManager = appManager;
 
-        _appManager.MainWindowLoaded += OnMainWindowLoaded;
+        _appManager.MainViewLoaded += OnMainViewLoaded;
     }
 
-    private void OnMainWindowLoaded(object? sender, EventArgs e)
+    private void OnMainViewLoaded(object? sender, EventArgs e)
     {
         foreach (SimpleDialogBuilder dialog in _dialogs)
         {
@@ -57,7 +57,7 @@ public class DialogManager : IDialogManager
                 break;
         }
 
-        if (_appManager.IsMainWindowLoaded)
+        if (_appManager.IsMainViewLoaded)
         {
             builder.Show();
         }
@@ -85,7 +85,7 @@ public class DialogManager : IDialogManager
             builder.WithCancelButton(tertiaryButton.Label, tertiaryButton.Action ?? (() => {}));
         }
 
-        if (_appManager.IsMainWindowLoaded)
+        if (_appManager.IsMainViewLoaded)
         {
             builder.Show();
         }
@@ -120,7 +120,7 @@ public class DialogManager : IDialogManager
                 break;
         }
 
-        if (_appManager.IsMainWindowLoaded)
+        if (_appManager.IsMainViewLoaded)
         {
             builder.Show();
         }
@@ -164,7 +164,7 @@ public class DialogManager : IDialogManager
             });
         }
 
-        if (_appManager.IsMainWindowLoaded)
+        if (_appManager.IsMainViewLoaded)
         {
             builder.Show();
         }

--- a/src/OverwatchServerBlocker.UI/Services/StoragePicker.cs
+++ b/src/OverwatchServerBlocker.UI/Services/StoragePicker.cs
@@ -20,7 +20,7 @@ public class StoragePicker : IStoragePicker
         {
             throw new Exception("Missing desktop lifetime reference");
         }
-        if (desktop.MainWindow is not MainWindow mainWindow)
+        if (desktop.MainWindow is not { } mainWindow)
         {
             throw new Exception("Missing top-level reference");
         }

--- a/src/OverwatchServerBlocker.UI/Services/ToastManager.cs
+++ b/src/OverwatchServerBlocker.UI/Services/ToastManager.cs
@@ -20,10 +20,10 @@ public class ToastManager : IToastManager
         Manager = manager;
         _appManager = appManager;
 
-        _appManager.MainWindowLoaded += OnMainWindowLoaded;
+        _appManager.MainViewLoaded += OnMainViewLoaded;
     }
 
-    private void OnMainWindowLoaded(object? sender, EventArgs e)
+    private void OnMainViewLoaded(object? sender, EventArgs e)
     {
         foreach ((ToastBuilder builder, ToastStyle style) toast in _toasts)
         {
@@ -45,7 +45,7 @@ public class ToastManager : IToastManager
             builder.WithAction(action.Label, action.Action);
         }
 
-        if (_appManager.IsMainWindowLoaded)
+        if (_appManager.IsMainViewLoaded)
         {
             Show(builder, style);
         }

--- a/src/OverwatchServerBlocker.UI/ShadMainWindow.axaml
+++ b/src/OverwatchServerBlocker.UI/ShadMainWindow.axaml
@@ -1,0 +1,38 @@
+<shadui:Window x:Class="OverwatchServerBlocker.UI.ShadMainWindow"
+               xmlns="https://github.com/avaloniaui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+               xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+               xmlns:designTime="clr-namespace:OverwatchServerBlocker.UI.DesignTime;assembly=OverwatchServerBlocker.UI"
+               xmlns:echoes="clr-namespace:Echoes;assembly=Echoes.Avalonia"
+               xmlns:localization="clr-namespace:OverwatchServerBlocker.Core.Localization;assembly=OverwatchServerBlocker.Core"
+               xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+               xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
+               xmlns:ui="clr-namespace:OverwatchServerBlocker.UI"
+               xmlns:views="clr-namespace:OverwatchServerBlocker.UI.Views"
+               xmlns:vm="clr-namespace:OverwatchServerBlocker.Core.ViewModels;assembly=OverwatchServerBlocker.Core"
+               Title="{echoes:Translate {x:Static localization:Misc.window_title}}"
+               MinWidth="790"
+               MinHeight="340"
+               d:DesignHeight="450"
+               d:DesignWidth="800"
+               x:DataType="vm:MainViewModel"
+               Icon="/Assets/logo-gray.ico"
+               SaveWindowState="True"
+               ShowBottomBorder="False"
+               TitleFontWeight="SemiBold"
+               mc:Ignorable="d">
+    <Design.DataContext>
+        <designTime:Locator Type="{x:Type vm:MainViewModel}" />
+    </Design.DataContext>
+
+    <shadui:Window.DataTemplates>
+        <ui:ViewLocator />
+    </shadui:Window.DataTemplates>
+
+    <shadui:Window.LogoContent>
+        <Image Margin="18,8,8,8"
+               Source="/Assets/logo-transparent.png" />
+    </shadui:Window.LogoContent>
+
+    <views:MainView DataContext="{Binding}" />
+</shadui:Window>

--- a/src/OverwatchServerBlocker.UI/ShadMainWindow.axaml.cs
+++ b/src/OverwatchServerBlocker.UI/ShadMainWindow.axaml.cs
@@ -1,0 +1,19 @@
+using Avalonia.Controls;
+using Window = ShadUI.Window;
+
+namespace OverwatchServerBlocker.UI;
+
+public partial class ShadMainWindow : Window
+{
+    public ShadMainWindow()
+    {
+        InitializeComponent();
+
+#if DEBUG
+        if (Design.IsDesignMode)
+        {
+            TitleBarAnimationEnabled = false;
+        }
+#endif
+    }
+}

--- a/src/OverwatchServerBlocker.UI/Views/MainView.axaml
+++ b/src/OverwatchServerBlocker.UI/Views/MainView.axaml
@@ -1,0 +1,152 @@
+﻿<UserControl x:Class="OverwatchServerBlocker.UI.Views.MainView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:OverwatchServerBlocker.UI.Converters"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:designTime="clr-namespace:OverwatchServerBlocker.UI.DesignTime;assembly=OverwatchServerBlocker.UI"
+             xmlns:echoes="clr-namespace:Echoes;assembly=Echoes.Avalonia"
+             xmlns:iconPacks="https://github.com/MahApps/IconPacks.Avalonia"
+             xmlns:localization="clr-namespace:OverwatchServerBlocker.Core.Localization;assembly=OverwatchServerBlocker.Core"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:services="clr-namespace:OverwatchServerBlocker.Core.Services;assembly=OverwatchServerBlocker.Core"
+             xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
+             xmlns:ui="clr-namespace:OverwatchServerBlocker.UI"
+             xmlns:vm="clr-namespace:OverwatchServerBlocker.Core.ViewModels;assembly=OverwatchServerBlocker.Core"
+             d:DesignHeight="450"
+             d:DesignWidth="800"
+             x:DataType="vm:MainViewModel"
+             Background="{DynamicResource WindowBackgroundColor}"
+             mc:Ignorable="d">
+    <Design.DataContext>
+        <designTime:Locator Type="{x:Type vm:MainViewModel}" />
+    </Design.DataContext>
+
+    <UserControl.DataTemplates>
+        <ui:ViewLocator />
+    </UserControl.DataTemplates>
+
+    <UserControl.Styles>
+        <Style Selector="PathIcon#CheckSelected">
+            <Setter Property="FlowDirection" Value="LeftToRight" />
+        </Style>
+        <Style Selector="PathIcon#PartIcon">
+            <Setter Property="FlowDirection" Value="LeftToRight" />
+        </Style>
+    </UserControl.Styles>
+
+    <Panel>
+        <Grid ColumnDefinitions="Auto, *">
+            <shadui:Sidebar Grid.Column="0"
+                            Width="220"
+                            MinWidth="60"
+                            Padding="{Binding #Toggler.IsChecked, Converter={x:Static converters:BooleanConverters.SidebarPadding}}"
+                            BorderBrush="{DynamicResource BorderColor30}"
+                            BorderThickness="0,0,1,0"
+                            CurrentRoute="{Binding Navigation.CurrentPage.Route}"
+                            Expanded="{Binding #Toggler.IsChecked}">
+                <shadui:Sidebar.Header>
+                    <ToggleButton Name="Toggler"
+                                  Height="32"
+                                  Padding="8"
+                                  HorizontalAlignment="{Binding #Toggler.IsChecked, Converter={x:Static converters:BooleanConverters.SidebarTogglerHorizontalAlignment}}"
+                                  CornerRadius="{DynamicResource LgCornerRadius}"
+                                  Theme="{DynamicResource SideTogglerTheme}"
+                                  ToolTip.ServiceEnabled="{Binding !$parent[shadui:Sidebar].Expanded}"
+                                  ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.nav_expand}}">
+                        <iconPacks:PackIconFontAwesome Width="16"
+                                                       Height="16"
+                                                       HorizontalAlignment="Center"
+                                                       Kind="BarsStaggeredSolid" />
+                    </ToggleButton>
+                </shadui:Sidebar.Header>
+
+                <shadui:Sidebar.ExpandEasing>
+                    <shadui:EaseInOutBack BounceIntensity="Strong" />
+                </shadui:Sidebar.ExpandEasing>
+
+                <StackPanel Spacing="4">
+                    <shadui:SidebarItemLabel AsSeparator="True" />
+                    <shadui:SidebarItem Command="{Binding Navigation.NavigateCommand}"
+                                        CommandParameter="{x:Static services:Pages.Servers}"
+                                        Content="{echoes:Translate {x:Static localization:Misc.nav_servers}}"
+                                        Route="Servers"
+                                        ToolTip.ServiceEnabled="{Binding !$parent[shadui:Sidebar].Expanded}"
+                                        ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.nav_servers}}">
+                        <shadui:SidebarItem.Icon>
+                            <iconPacks:PackIconFontAwesome Width="16"
+                                                           Height="16"
+                                                           VerticalAlignment="Center"
+                                                           Kind="ServerSolid" />
+                        </shadui:SidebarItem.Icon>
+                    </shadui:SidebarItem>
+                    <shadui:SidebarItem Command="{Binding Navigation.NavigateCommand}"
+                                        CommandParameter="{x:Static services:Pages.Settings}"
+                                        Content="{echoes:Translate {x:Static localization:Misc.nav_settings}}"
+                                        Route="Settings"
+                                        ToolTip.ServiceEnabled="{Binding !$parent[shadui:Sidebar].Expanded}"
+                                        ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.nav_settings}}">
+                        <shadui:SidebarItem.Icon>
+                            <iconPacks:PackIconFontAwesome Width="16"
+                                                           Height="16"
+                                                           VerticalAlignment="Center"
+                                                           Kind="GearsSolid" />
+                        </shadui:SidebarItem.Icon>
+                    </shadui:SidebarItem>
+                </StackPanel>
+
+                <shadui:Sidebar.Footer>
+                    <StackPanel Spacing="4">
+                        <StackPanel.Styles>
+                            <Style Selector="shadui|SidebarItem:checked /template/ Border#SelectedBackground">
+                                <Setter Property="Opacity" Value="0" />
+                            </Style>
+                        </StackPanel.Styles>
+
+                        <shadui:SidebarItem Command="{Binding OpenRepositoryCommand}"
+                                            Content="{echoes:Translate {x:Static localization:Misc.github}}"
+                                            GroupName="Footer"
+                                            ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.github_repository}}">
+                            <shadui:SidebarItem.Icon>
+                                <iconPacks:PackIconFontAwesome Width="16"
+                                                               Height="16"
+                                                               VerticalAlignment="Center"
+                                                               Kind="GithubBrands" />
+                            </shadui:SidebarItem.Icon>
+                        </shadui:SidebarItem>
+
+                        <shadui:SidebarItem Command="{Binding UpdateChecker.CheckForUpdatesCommand}"
+                                            Content="{echoes:Translate {x:Static localization:Misc.update}}"
+                                            GroupName="Footer"
+                                            ToolTip.Tip="{echoes:Translate {x:Static localization:Misc.check_update}}">
+                            <shadui:SidebarItem.Icon>
+                                <iconPacks:PackIconFontAwesome Width="16"
+                                                               Height="16"
+                                                               VerticalAlignment="Center"
+                                                               ClipToBounds="False"
+                                                               Kind="RotateSolid"
+                                                               Spin="{Binding UpdateChecker.IsCheckingUpdate}"
+                                                               SpinDuration="3" />
+                            </shadui:SidebarItem.Icon>
+                        </shadui:SidebarItem>
+
+                        <shadui:SidebarItemLabel AsSeparator="True" />
+
+                        <TextBlock x:Name="VersionLabel"
+                                   HorizontalAlignment="Center"
+                                   Classes="Muted"
+                                   FontWeight="Bold" />
+                    </StackPanel>
+                </shadui:Sidebar.Footer>
+            </shadui:Sidebar>
+            <ContentControl Grid.Column="1"
+                            Content="{Binding Navigation.CurrentPage}" />
+        </Grid>
+
+        <shadui:PopupMask>
+            <shadui:PopupMask.Hosts>
+                <shadui:DialogHost x:Name="DialogHost" />
+                <shadui:ToastHost x:Name="ToastHost" />
+            </shadui:PopupMask.Hosts>
+        </shadui:PopupMask>
+    </Panel>
+</UserControl>

--- a/src/OverwatchServerBlocker.UI/Views/MainView.axaml.cs
+++ b/src/OverwatchServerBlocker.UI/Views/MainView.axaml.cs
@@ -1,0 +1,53 @@
+﻿using Avalonia.Controls;
+using OverwatchServerBlocker.Core.ViewModels;
+using OverwatchServerBlocker.UI.Services;
+using System;
+using System.Reflection;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+
+namespace OverwatchServerBlocker.UI.Views;
+
+public partial class MainView : UserControl
+{
+    public MainView()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+
+        string? version = Assembly.GetEntryAssembly()?.GetName().Version?.ToString(3);
+        VersionLabel.Text = version;
+    }
+
+    protected override void OnDataContextChanged(EventArgs e)
+    {
+        if (DataContext is MainViewModel mainViewModel)
+        {
+            if (mainViewModel.DialogManager is DialogManager dialogManager)
+            {
+                DialogHost.Manager = dialogManager.Manager;
+            }
+
+            if (mainViewModel.ToastManager is ToastManager toastManager)
+            {
+                ToastHost.Manager = toastManager.Manager;
+            }
+        }
+
+        base.OnDataContextChanged(e);
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        if (DataContext is MainViewModel mainViewModel)
+        {
+            mainViewModel.AppManager.InvokeMainViewLoaded(this);
+        }
+
+        base.OnLoaded(e);
+    }
+}


### PR DESCRIPTION
Replaces the main window content with a new MainView user control, moving sidebar and layout logic into MainView. Adds ShadMainWindow for Windows with ShadUI styling, and integrates the shad-ui submodule as a project reference. Updates IAppManager and related services to use 'MainView' terminology instead of 'MainWindow'. Localization and UI logic are updated to support the new structure.