### PR TITLE
Refactor to use App.TopLevel for services

### DIFF
--- a/src/OverwatchServerBlocker.UI/App.axaml.cs
+++ b/src/OverwatchServerBlocker.UI/App.axaml.cs
@@ -21,6 +21,8 @@ namespace OverwatchServerBlocker.UI;
 
 public partial class App : Application
 {
+    public static TopLevel? TopLevel { get; private set; } = null;
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -77,6 +79,7 @@ public partial class App : Application
             DataContext = Singletons.ServiceProvider?.GetRequiredService<MainViewModel>()
         };
 #endif
+        TopLevel = lifetime.MainWindow;
     }
 
     private void ManagerOnCultureChanged(object? sender, string e)
@@ -84,13 +87,6 @@ public partial class App : Application
         CultureInfo info = CultureInfo.GetCultureInfo(e);
         TranslationProvider.SetCulture(info);
 
-        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime { MainWindow: not null } desktop)
-        {
-            desktop.MainWindow.FlowDirection = info.TextInfo.IsRightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
-        }
-        else if (ApplicationLifetime is ISingleViewApplicationLifetime { MainView: not null } singleView)
-        {
-            singleView.MainView.FlowDirection = info.TextInfo.IsRightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
-        }
+        TopLevel?.FlowDirection = info.TextInfo.IsRightToLeft ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
     }
 }

--- a/src/OverwatchServerBlocker.UI/Services/AppManager.cs
+++ b/src/OverwatchServerBlocker.UI/Services/AppManager.cs
@@ -36,7 +36,7 @@ public class AppManager : IAppManager
         };
     }
 
-    public bool CheckView()
+    private static bool CheckView()
     {
         if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {

--- a/src/OverwatchServerBlocker.UI/Services/Clipboard.cs
+++ b/src/OverwatchServerBlocker.UI/Services/Clipboard.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Avalonia;
-using Avalonia.Controls.ApplicationLifetimes;
 using OverwatchServerBlocker.Core.Services;
 
 namespace OverwatchServerBlocker.UI.Services;
@@ -10,19 +8,11 @@ public class Clipboard : IClipboard
 {
     public async Task SetTextAsync(string text)
     {
-        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime lifetime)
+        if (App.TopLevel?.Clipboard is not {} clipboard)
         {
-            throw new Exception("Failed to get the application lifetime.");
-        }
-        if (lifetime.MainWindow is null)
-        {
-            throw new Exception("Failed to get the main window.");
-        }
-        if (lifetime.MainWindow.Clipboard is null)
-        {
-            throw new Exception("Failed to get the clipboard.");
+            throw new Exception("Failed to get the clipboard service.");
         }
 
-        await lifetime.MainWindow.Clipboard.SetTextAsync(text);
+        await clipboard.SetTextAsync(text);
     }
 }

--- a/src/OverwatchServerBlocker.UI/Services/StoragePicker.cs
+++ b/src/OverwatchServerBlocker.UI/Services/StoragePicker.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Avalonia;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Platform.Storage;
 using OverwatchServerBlocker.Core.Services;
 using FilePickerOpenOptions = OverwatchServerBlocker.Core.Services.FilePickerOpenOptions;
@@ -16,20 +14,16 @@ public class StoragePicker : IStoragePicker
 {
     public async Task<IReadOnlyList<string>> OpenFilePickerAsync(FilePickerOpenOptions options)
     {
-        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+        if (App.TopLevel?.StorageProvider is not {} storageProvider)
         {
-            throw new Exception("Missing desktop lifetime reference");
-        }
-        if (desktop.MainWindow is not { } mainWindow)
-        {
-            throw new Exception("Missing top-level reference");
+            throw new Exception("Failed to get the storage provider service.");
         }
 
         AvaFilePickerOpenOptions avaOptions = new()
         {
             Title = options.Title,
             AllowMultiple = options.AllowMultiple,
-            SuggestedStartLocation = options.SuggestedStartLocation is null ? null : await mainWindow.StorageProvider.TryGetFolderFromPathAsync(options.SuggestedStartLocation),
+            SuggestedStartLocation = options.SuggestedStartLocation is null ? null : await storageProvider.TryGetFolderFromPathAsync(options.SuggestedStartLocation),
             FileTypeFilter = options.FileTypeFilter is { } filter
                 ? filter.Select(f => new FilePickerFileType(f.Name)
                 {
@@ -38,7 +32,7 @@ public class StoragePicker : IStoragePicker
                 : null
         };
 
-        IReadOnlyList<IStorageFile> files = await mainWindow.StorageProvider.OpenFilePickerAsync(avaOptions);
+        IReadOnlyList<IStorageFile> files = await storageProvider.OpenFilePickerAsync(avaOptions);
         return files.Select(f => f.Path.LocalPath).ToArray();
     }
 }


### PR DESCRIPTION
Centralizes access to services (Clipboard, StorageProvider, FlowDirection) via a new static App.TopLevel property. Simplifies service access and reduces repeated lifetime checks across the application.